### PR TITLE
Task 2: Adding instant search

### DIFF
--- a/apps/okreads-e2e/src/integration/search-books.spec.ts
+++ b/apps/okreads-e2e/src/integration/search-books.spec.ts
@@ -8,10 +8,12 @@ describe('When: Use the search feature', () => {
 
     cy.get('form').submit();
 
-    cy.get('[data-testing="book-item"]').should('have.length.greaterThan', 1);
+    cy.get('[data-testing="book-item"]').should('have.length.greaterThan', 0);
   });
 
-  xit('Then: I should see search results as I am typing', () => {
-    // TODO: Implement this test!
+  it('Then: I should see search results as I am typing', () => {
+    cy.get('input[type="search"]').type('java');
+
+    cy.get('[data-testing="book-item"]').should('have.length.greaterThan', 0);
   });
 });

--- a/libs/books/feature/src/lib/book-search/book-search.component.spec.ts
+++ b/libs/books/feature/src/lib/book-search/book-search.component.spec.ts
@@ -1,27 +1,71 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  async,
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick
+} from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SharedTestingModule } from '@tmo/shared/testing';
 
 import { BooksFeatureModule } from '../books-feature.module';
 import { BookSearchComponent } from './book-search.component';
+import { clearSearch, searchBooks } from '@tmo/books/data-access';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 
-describe('ProductsListComponent', () => {
+describe('Book Search Component', () => {
   let component: BookSearchComponent;
   let fixture: ComponentFixture<BookSearchComponent>;
+  let store: MockStore;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [BooksFeatureModule, NoopAnimationsModule, SharedTestingModule]
+      imports: [BooksFeatureModule, NoopAnimationsModule, SharedTestingModule],
+      providers: [provideMockStore()]
     }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(BookSearchComponent);
     component = fixture.componentInstance;
+    store = TestBed.inject(MockStore);
+    jest.spyOn(store, 'dispatch');
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeDefined();
+  });
+
+  describe('Handle instant search change', () => {
+    it('should dispatch an action as on typing on the form control considering debounce time', fakeAsync(() => {
+      component.searchForm.setValue({ term: 'java' });
+      tick(300);
+      expect(store.dispatch).not.toHaveBeenCalled();
+      component.searchForm.setValue({ term: 'javac' });
+      tick(500);
+      expect(store.dispatch).toHaveBeenCalledWith(searchBooks({ term: 'javac' }));
+    }));
+
+    it('should not dispatch searchBooks action when search field is not changed after 500 ms debounce', fakeAsync(() => {
+      component.searchForm.setValue({ term: 'java' });
+      tick(500);
+      expect(store.dispatch).toHaveBeenCalledWith(
+        searchBooks({ term: 'java' })
+      );
+
+      component.searchForm.setValue({ term: 'javas' });
+      component.searchForm.setValue({ term: 'java' });
+      tick(500);
+      expect(store.dispatch).toHaveBeenCalledWith(
+        searchBooks({ term: 'java' })
+      );
+    }));
+
+    it('should dispatch clearSearch action when search term is changed and is empty', fakeAsync(() => {
+      component.searchForm.setValue({ term: '' });
+      tick(500);
+      expect(store.dispatch).toHaveBeenCalledWith(clearSearch());
+    }));
   });
 });

--- a/libs/books/feature/src/lib/book-search/book-search.component.ts
+++ b/libs/books/feature/src/lib/book-search/book-search.component.ts
@@ -1,30 +1,45 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
 import {
   addToReadingList,
   clearSearch,
   getAllBooks,
-  searchBooks
+  searchBooks,
 } from '@tmo/books/data-access';
 import { FormBuilder } from '@angular/forms';
 import { Book } from '@tmo/shared/models';
+import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
+import { Subject, Subscription } from 'rxjs';
 
 @Component({
   selector: 'tmo-book-search',
   templateUrl: './book-search.component.html',
-  styleUrls: ['./book-search.component.scss']
+  styleUrls: ['./book-search.component.scss'],
 })
-
-export class BookSearchComponent {
+export class BookSearchComponent implements OnInit, OnDestroy {
   books$ = this.store.select(getAllBooks);
+  subscription = new Subscription();
   searchForm = this.fb.group({
-    term: ''
+    term: '',
   });
+  destroy$: Subject<boolean> = new Subject<boolean>();
+
 
   constructor(
     private readonly store: Store,
-    private readonly fb: FormBuilder
-  ) {}
+    private readonly fb: FormBuilder,
+  ) {
+   }
+
+  ngOnInit(): void {
+
+    this.searchForm.get('term').valueChanges
+    .pipe(
+      debounceTime(500),
+      distinctUntilChanged(),
+      takeUntil(this.destroy$.asObservable())
+    ).subscribe(() => this.searchBooks());
+  }
 
   addBookToReadingList(book: Book) {
     this.store.dispatch(addToReadingList({ book }));
@@ -32,14 +47,18 @@ export class BookSearchComponent {
 
   searchExample() {
     this.searchForm.controls.term.setValue('javascript');
-    this.searchBooks();
   }
 
   searchBooks() {
     if (this.searchForm.value.term) {
-      this.store.dispatch(searchBooks({ term: this.searchForm.value.term }));
+      this.store.dispatch(searchBooks({ term: this.searchForm.value.term}));
     } else {
       this.store.dispatch(clearSearch());
     }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.unsubscribe();
   }
 }


### PR DESCRIPTION
As a user, I want to see book results as I am typing in the search field -- I don't want to have to submit the form.

Starting from the chore/code-review branch from Task 1, create a new branch feat/instant-search.
Update the code to provide instant search results as the user is typing. Be sure not to spam the API with too many calls -- no more than one request every 500 ms.
Open the e2e test file apps/okreads-e2e/src/specs/search-books.spec.ts. Enable the second spec by renaming xit to it, then implement the test to ensure instant search works.
Commit your changes to the feature branch and open a pull-request with chore/code-review as the target.