### PR TITLE
Task 3: Undo add and remove from reading list

### DIFF
--- a/apps/okreads-e2e/src/integration/reading-list.spec.ts
+++ b/apps/okreads-e2e/src/integration/reading-list.spec.ts
@@ -1,6 +1,9 @@
 describe('When: I use the reading list feature', () => {
   beforeEach(() => {
     cy.startAt('/');
+    cy.get('input[type="search"]').type('javascript');
+    cy.get('form').submit();
+    cy.get('[data-testing="book-item"]').should('have.length.greaterThan', 0);
   });
 
   it('Then: I should see my reading list', () => {
@@ -11,4 +14,36 @@ describe('When: I use the reading list feature', () => {
       'My Reading List'
     );
   });
+
+  it('Then: I should be able to undo add book action on reading list side nav', () => {
+    removeAllItemsFromReadingList();
+    cy.get('[data-testing="want-to-read-btn"]').first().click();
+    cy.get('[data-testing="reading-list-item"]').should('have.length', 1);
+    cy.get('.mat-simple-snackbar').should('be.visible');
+
+    cy.get('.mat-simple-snackbar-action .mat-button').click();
+    cy.get('[data-testing="reading-list-item"]').should('not.exist');
+  });
+
+  it('Then: I should be able to undo remove book action on reading list side nav', () => {
+    removeAllItemsFromReadingList();
+    cy.get('[data-testing="want-to-read-btn"]').first().click();
+    cy.get('[data-testing="reading-list-item"]').should('have.length', 1);
+
+    cy.get('[data-testing="toggle-reading-list"]').click();
+    cy.get('[data-testing="remove-btn"]').first().click();
+    cy.get('[data-testing="reading-list-item"]').should('not.exist');
+    cy.get('.mat-simple-snackbar').should('be.visible');
+
+    cy.get('.mat-simple-snackbar-action .mat-button').click();
+    cy.get('[data-testing="reading-list-item"]').should('have.length', 1);
+  });
 });
+
+function removeAllItemsFromReadingList() {
+  cy.get('[data-testing="toggle-reading-list"]').click();
+  cy.get('[data-testing="reading-list-container"]').then((container) => {
+    container.find('[data-testing="remove-btn"]').trigger('click');
+  });
+  cy.get('[data-testing="close-btn"]').click();
+}

--- a/apps/okreads/browser/src/app/app.component.html
+++ b/apps/okreads/browser/src/app/app.component.html
@@ -25,6 +25,7 @@
         My Reading List
         <button mat-icon-button 
         aria-label="Close Reading List"
+        data-testing="close-btn"
         (click)="drawer.close()">
           <mat-icon>close</mat-icon>
         </button>

--- a/libs/books/data-access/src/lib/+state/reading-list.actions.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.actions.ts
@@ -14,7 +14,7 @@ export const loadReadingListError = createAction(
 
 export const addToReadingList = createAction(
   '[Books Search Results] Add to list',
-  props<{ book: Book }>()
+  props<{ book: Book; showSnackbar?: boolean }>()
 );
 
 export const failedAddToReadingList = createAction(
@@ -24,12 +24,12 @@ export const failedAddToReadingList = createAction(
 
 export const confirmedAddToReadingList = createAction(
   '[Reading List API] Confirmed add to list',
-  props<{ book: Book }>()
+  props<{ data: Book; showSnackbar: boolean; isAdded: boolean }>()
 );
 
 export const removeFromReadingList = createAction(
   '[Books Search Results] Remove from list',
-  props<{ item: ReadingListItem }>()
+  props<{ item: ReadingListItem; showSnackbar?: boolean }>()
 );
 
 export const failedRemoveFromReadingList = createAction(
@@ -39,5 +39,5 @@ export const failedRemoveFromReadingList = createAction(
 
 export const confirmedRemoveFromReadingList = createAction(
   '[Reading List API] Confirmed remove from list',
-  props<{ item: ReadingListItem }>()
+  props<{ data: ReadingListItem; showSnackbar: boolean; isAdded: boolean }>()
 );

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
@@ -8,32 +8,34 @@ import { SharedTestingModule } from '@tmo/shared/testing';
 import { ReadingListEffects } from './reading-list.effects';
 import * as ReadingListActions from './reading-list.actions';
 import { API_PATH } from '../constants';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
-describe('To Initialize effects ', () => {
+describe('Test Suite for Reading list effect ', () => {
   let actions: ReplaySubject<any>;
   let effects: ReadingListEffects;
   let httpMock: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SharedTestingModule],
+      imports: [SharedTestingModule, MatSnackBarModule, NoopAnimationsModule],
       providers: [
         ReadingListEffects,
         provideMockActions(() => actions),
-        provideMockStore(),
-      ],
+        provideMockStore()
+      ]
     });
 
     effects = TestBed.inject(ReadingListEffects);
     httpMock = TestBed.inject(HttpTestingController);
   });
 
-  describe('loadReadingList$', () => {
-    it('should work', (done) => {
+  describe('Test suite to load ReadingList$', () => {
+    it('should load reading list', done => {
       actions = new ReplaySubject();
       actions.next(ReadingListActions.init());
 
-      effects.loadReadingList$.subscribe((action) => {
+      effects.loadReadingList$.subscribe(action => {
         expect(action).toEqual(
           ReadingListActions.loadReadingListSuccess({ list: [] })
         );

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.ts
@@ -2,10 +2,18 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Actions, createEffect, ofType, OnInitEffects } from '@ngrx/effects';
 import { of } from 'rxjs';
-import { catchError, concatMap, exhaustMap, map } from 'rxjs/operators';
-import { ReadingListItem } from '@tmo/shared/models';
+import {
+  catchError,
+  concatMap,
+  exhaustMap,
+  map,
+  filter,
+  switchMap
+} from 'rxjs/operators';
+import { ReadingListItem, Book } from '@tmo/shared/models';
 import * as ReadingListActions from './reading-list.actions';
-import { API_PATH } from '../constants';
+import { API_PATH, SNACKBAR_ALERT } from '../constants';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Injectable()
 export class ReadingListEffects implements OnInitEffects {
@@ -17,7 +25,7 @@ export class ReadingListEffects implements OnInitEffects {
           map(data =>
             ReadingListActions.loadReadingListSuccess({ list: data })
           ),
-          catchError((error) =>
+          catchError(error =>
             of(ReadingListActions.loadReadingListError({ error }))
           )
         )
@@ -28,9 +36,15 @@ export class ReadingListEffects implements OnInitEffects {
   addBook$ = createEffect(() =>
     this.actions$.pipe(
       ofType(ReadingListActions.addToReadingList),
-      concatMap(({ book }) =>
+      concatMap(({ book, showSnackbar = true }) =>
         this.http.post(API_PATH.READING_LIST, book).pipe(
-          map(() => ReadingListActions.confirmedAddToReadingList({ book })),
+          map(() =>
+            ReadingListActions.confirmedAddToReadingList({
+              data: book,
+              showSnackbar,
+              isAdded: true
+            })
+          ),
           catchError(() =>
             of(ReadingListActions.failedAddToReadingList({ book }))
           )
@@ -42,10 +56,14 @@ export class ReadingListEffects implements OnInitEffects {
   removeBook$ = createEffect(() =>
     this.actions$.pipe(
       ofType(ReadingListActions.removeFromReadingList),
-      concatMap(({ item }) =>
+      concatMap(({ item, showSnackbar = true }) =>
         this.http.delete(`${API_PATH.READING_LIST}/${item.bookId}`).pipe(
           map(() =>
-            ReadingListActions.confirmedRemoveFromReadingList({ item })
+            ReadingListActions.confirmedRemoveFromReadingList({
+              data: item,
+              showSnackbar,
+              isAdded: false
+            })
           ),
           catchError(() =>
             of(ReadingListActions.failedRemoveFromReadingList({ item }))
@@ -55,9 +73,51 @@ export class ReadingListEffects implements OnInitEffects {
     )
   );
 
+  showSnackbar$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(
+        ReadingListActions.confirmedAddToReadingList,
+        ReadingListActions.confirmedRemoveFromReadingList
+      ),
+      filter(({ showSnackbar }) => showSnackbar),
+      switchMap(({ data, isAdded }) =>
+        this.snackbar
+          .open(
+            isAdded ? SNACKBAR_ALERT.ADD_A_BOOK : SNACKBAR_ALERT.REMOVE_A_BOOK,
+            SNACKBAR_ALERT.UNDO_AN_ACTION,
+            {
+              duration: SNACKBAR_ALERT.TIMEOUT
+            }
+          )
+          .onAction()
+          .pipe(
+            map(() => {
+              if (isAdded) {
+                const book = data as Book;
+                return ReadingListActions.removeFromReadingList({
+                  item: { ...book, bookId: book.id },
+                  showSnackbar: false
+                });
+              } else {
+                const item = data as ReadingListItem;
+                return ReadingListActions.addToReadingList({
+                  book: { ...item, id: item.bookId },
+                  showSnackbar: false
+                });
+              }
+            })
+          )
+      )
+    )
+  );
+
   ngrxOnInitEffects() {
     return ReadingListActions.init();
   }
 
-  constructor(private actions$: Actions, private http: HttpClient) {}
+  constructor(
+    private actions$: Actions,
+    private http: HttpClient,
+    private readonly snackbar: MatSnackBar
+  ) { }
 }

--- a/libs/books/data-access/src/lib/constants.ts
+++ b/libs/books/data-access/src/lib/constants.ts
@@ -2,3 +2,10 @@ export const API_PATH = {
     READING_LIST: '/api/reading-list',
     BOOKS_SEARCH: '/api/books/search?q='
 };
+
+export const SNACKBAR_ALERT = {
+    ADD_A_BOOK: 'Added book to reading list',
+    REMOVE_A_BOOK: 'Removed book from reading list',
+    UNDO_AN_ACTION: 'Undo',
+    TIMEOUT: 3000
+};

--- a/libs/books/feature/src/lib/book-search/book-search.component.html
+++ b/libs/books/feature/src/lib/book-search/book-search.component.html
@@ -1,25 +1,16 @@
 <form [formGroup]="searchForm" (submit)="searchBooks()">
   <mat-form-field floatLabel="never">
-    <input
-      autoFocus
-      matInput
-      type="search"
-      placeholder="Search for books to add to your reading list"
-      formControlName="term"
-    />
+    <input autoFocus matInput type="search" placeholder="Search for books to add to your reading list"
+      formControlName="term" />
     <button class="search-icon" aria-label="Search" mat-icon-button matSuffix>
       <mat-icon>search</mat-icon>
     </button>
   </mat-form-field>
 </form>
 
-<ng-container *ngIf= "searchForm.value.term; else empty">
+<ng-container *ngIf="searchForm.value.term; else empty">
   <div class="book-grid">
-    <div
-      class="book"
-      data-testing="book-item"
-      *ngFor="let book of books$ | async"
-    >
+    <div class="book" data-testing="book-item" *ngFor="let book of books$ | async">
       <div class="book--title">
         {{ book.title }}
       </div>
@@ -36,13 +27,8 @@
           </div>
           <p [innerHTML]="book.description"></p>
           <div>
-            <button
-              mat-flat-button
-              color="primary"
-              (click)="addBookToReadingList(book)"
-              [disabled]="book.isAdded"
-              [attr.aria-label]="'Want to read ' + book.title"
-            >
+            <button data-testing="want-to-read-btn" mat-flat-button color="primary" (click)="addBookToReadingList(book)"
+              [disabled]="book.isAdded" [attr.aria-label]="'Want to read ' + book.title">
               Want to Read
             </button>
           </div>
@@ -54,11 +40,8 @@
 <ng-template #empty>
   <div class="empty">
     <p>
-      Try searching for a topic, for example "<button
-        (click)="searchExample()"
-      >
-        JavaScript</button
-      >".
+      Try searching for a topic, for example "<button (click)="searchExample()">
+        JavaScript</button>".
     </p>
   </div>
 </ng-template>

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.html
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.html
@@ -1,23 +1,19 @@
 <ng-container *ngIf="(readingList$ | async).length > 0; else empty">
-  <div class="reading-list-item" *ngFor="let book of readingList$ | async">
+  <div class="reading-list-item" data-testing="reading-list-item" *ngFor="let book of readingList$ | async">
     <div>
       <img class="reading-list-item--cover" [src]="book.coverUrl" alt="" />
     </div>
     <div class="reading-list-item--details">
       <strong class="reading-list-item--details--title">{{
         book.title
-      }}</strong>
+        }}</strong>
       <div class="reading-list-item--details--author">
         {{ book.authors.join(',') }}
       </div>
     </div>
     <div>
-      <button
-        mat-icon-button
-        color="warn"
-        [attr.aria-label]="'Remove ' + book.title + ' from reading list'"
-        (click)="removeFromReadingList(book)"
-      >
+      <button data-testing="remove-btn" mat-icon-button color="warn"
+        [attr.aria-label]="'Remove ' + book.title + ' from reading list'" (click)="removeFromReadingList(book)">
         <mat-icon>remove_circle</mat-icon>
       </button>
     </div>


### PR DESCRIPTION
As a user, I want to be able to quickly undo my action when clicking the Want to Read button in the book list, or the remove button in the reading list.

Starting from the chore/code-review branch from Task 1, create a new branch feat/undo-actions.
Update the code such that a [snackbar](https://material.angular.io/components/snack-bar/overview) appears whenever the user adds or removes a book. (Hint: this module is already installed and set up)
The snackbar must display the event that occurred (i.e. added/removed), and an Undo action.
When the user clicks Undo, it should return the reading list state to the previous state.
Write a new e2e test in apps/okreads-e2e/src/specs/reading-list.spec.ts to test the new undo feature.
Commit your changes on the feature branch and open a pull-request with chore/code-review as the target.