### PR TITLE
Task 4: Ability to mark a book as finished

### DIFF
--- a/apps/okreads-e2e/src/integration/reading-list.spec.ts
+++ b/apps/okreads-e2e/src/integration/reading-list.spec.ts
@@ -12,3 +12,58 @@ describe('When: I use the reading list feature', () => {
     );
   });
 });
+describe('When: I use the reading list feature', () => {
+  beforeEach(() => {
+    cy.startAt('/');
+    cy.get('input[type="search"]').type('javascript');
+    cy.get('form').submit();
+    cy.get('[data-testing="book-item"]').should('have.length.greaterThan', 0);
+  });
+
+  it('Then: I should see my reading list', () => {
+    cy.get('[data-testing="toggle-reading-list"]').click();
+
+    cy.get('[data-testing="reading-list-container"]').should(
+      'contain.text',
+      'My Reading List'
+    );
+  });
+
+  it('Then: I should be able to mark book as finished and remove finished book from reading list side nav', () => {
+    removeItemsFromReadingList();
+    cy.get('[data-testing="want-to-read-btn"]').first().click({ multiple: true, force: true });
+    cy.get('[data-testing="reading-list-item"]').should('have.length', 1);
+
+    cy.get('[data-testing="toggle-reading-list"]').click({ multiple: true, force: true });
+    cy.get('[data-testing="finished-btn"]').first().click({ multiple: true, force: true });
+
+    // we need to verify if finished button and finished date are displayed when book is marked as done
+    cy.get('[data-testing="reading-list-item"]').within(() => {
+      cy.get('[data-testing="finished-btn"]').should('be.visible');
+      cy.get('[data-testing="finished-date"]').should('be.visible');
+    });
+
+    // we need to verify if want to read button disabled and text changed to "Finished" when book is marked as done,should be shown in automation testing
+    cy.get('[data-testing="toggle-reading-list"]').click({ multiple: true, force: true });
+    cy.get('[data-testing="want-to-read-btn"]')
+      .first()
+      .should('be.disabled')
+      .should('contain.text', 'Finished');
+
+    cy.get('[data-testing="remove-btn"]').first().click({ multiple: true, force: true });
+
+    // we need to verify if want to read button enabled and text changed to "Want to Read" when finished book removed from reading list side nav,should be shown in automation testing
+    cy.get('[data-testing="want-to-read-btn"]')
+      .first()
+      .should('be.enabled')
+      .should('contain.text', 'Want to Read');
+  });
+});
+
+function removeItemsFromReadingList() {
+  cy.get('[data-testing="toggle-reading-list"]').click();
+  cy.get('[data-testing="reading-list-container"]').then(container => {
+    container.find('[data-testing="remove-btn"]').trigger('click');
+  });
+  cy.get('[data-testing="close-btn"]').click();
+}

--- a/apps/okreads/browser/src/app/app.component.html
+++ b/apps/okreads/browser/src/app/app.component.html
@@ -24,6 +24,7 @@
       <h2>
         My Reading List
         <button mat-icon-button 
+        data-testing="close-btn"
         aria-label="Close Reading List"
         (click)="drawer.close()">
           <mat-icon>close</mat-icon>

--- a/libs/api/books/src/lib/reading-list.controller.ts
+++ b/libs/api/books/src/lib/reading-list.controller.ts
@@ -1,10 +1,10 @@
-import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
-import { Book } from '@tmo/shared/models';
+import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { Book, ReadingListItem } from '@tmo/shared/models';
 import { ReadingListService } from './reading-list.service';
 
 @Controller()
 export class ReadingListController {
-  constructor(private readonly readingList: ReadingListService) {}
+  constructor(private readonly readingList: ReadingListService) { }
 
   @Get('/reading-list/')
   async getReadingList() {
@@ -19,5 +19,10 @@ export class ReadingListController {
   @Delete('/reading-list/:id')
   async removeFromReadingList(@Param() params) {
     return await this.readingList.removeBook(params.id);
+  }
+
+  @Put('/reading-list/:id/finished')
+  async markBookAsFinished(@Body() item: ReadingListItem) {
+    return await this.readingList.markAsFinished(item, item.finishedDate);
   }
 }

--- a/libs/api/books/src/lib/reading-list.service.ts
+++ b/libs/api/books/src/lib/reading-list.service.ts
@@ -17,7 +17,7 @@ export class ReadingListService {
       const { id, ...rest } = b;
       list.push({
         bookId: id,
-        ...rest
+        ...rest,
       });
       return list;
     });
@@ -28,4 +28,13 @@ export class ReadingListService {
       return list.filter(x => x.bookId !== id);
     });
   }
+
+  async markAsFinished(item: ReadingListItem, finishedDate: string): Promise<void> {
+    this.storage.update(list => {
+      return list.map(bookList => {
+        return bookList.bookId !== item.bookId ? bookList : { ...bookList, finishedDate, finished: true };
+      });
+    });
+  }
+
 }

--- a/libs/books/data-access/src/lib/+state/reading-list.actions.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.actions.ts
@@ -41,3 +41,18 @@ export const confirmedRemoveFromReadingList = createAction(
   '[Reading List API] Confirmed remove from list',
   props<{ item: ReadingListItem }>()
 );
+
+export const markBookAsFinished = createAction(
+  '[Reading List API] Mark book as finished',
+  props<{ item: ReadingListItem }>()
+);
+
+export const confirmedMarkBookAsFinished = createAction(
+  '[Reading List API] Confirmed mark book as finished',
+  props<{ item: ReadingListItem }>()
+);
+
+export const failedMarkBookAsFinished = createAction(
+  '[Reading List API] Failed mark book as finished',
+  props<{ item: ReadingListItem }>()
+);

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
@@ -4,12 +4,15 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
 
-import { SharedTestingModule } from '@tmo/shared/testing';
+import {
+  SharedTestingModule,
+  createReadingListItem,
+} from '@tmo/shared/testing';
 import { ReadingListEffects } from './reading-list.effects';
 import * as ReadingListActions from './reading-list.actions';
 import { API_PATH } from '../constants';
 
-describe('To Initialize effects ', () => {
+describe('ToReadEffects', () => {
   let actions: ReplaySubject<any>;
   let effects: ReadingListEffects;
   let httpMock: HttpTestingController;
@@ -29,7 +32,7 @@ describe('To Initialize effects ', () => {
   });
 
   describe('loadReadingList$', () => {
-    it('should work', (done) => {
+    it('should work', done => {
       actions = new ReplaySubject();
       actions.next(ReadingListActions.init());
 
@@ -41,6 +44,54 @@ describe('To Initialize effects ', () => {
       });
 
       httpMock.expectOne(API_PATH.READING_LIST).flush([]);
+    });
+  });
+
+  describe('markBookAsFinished$', () => {
+    let item;
+    beforeEach(() => {
+      item = {
+        ...createReadingListItem('A'),
+        finished: true,
+        finishedDate: '2021-03-03T00:00:00.000Z',
+      };
+    });
+
+    it('should dispatch confirmedMarkBookAsFinished action when API returns success response', (done) => {
+      actions = new ReplaySubject();
+      actions.next(ReadingListActions.markBookAsFinished({ item }));
+      effects.markBookAsFinished$.subscribe((action) => {
+        expect(action).toEqual(
+          ReadingListActions.confirmedMarkBookAsFinished({
+            item,
+          })
+        );
+        done();
+      });
+
+      httpMock
+        .expectOne(`${API_PATH.READING_LIST}/A/finished`)
+        .flush({ ...item });
+    });
+
+    it('should dispatch failedMarkBookAsFinished action when API returns failure response', done => {
+      actions = new ReplaySubject();
+      actions.next(ReadingListActions.markBookAsFinished({ item }));
+      effects.markBookAsFinished$.subscribe(action => {
+        expect(action).toEqual(
+          ReadingListActions.failedMarkBookAsFinished({
+            item,
+          })
+        );
+        done();
+      });
+
+      httpMock
+        .expectOne(`${API_PATH.READING_LIST}/A/finished`)
+        .error(new ErrorEvent('HttpErrorResponse'), {
+          status: 500,
+          statusText: 'some error',
+        });
     });
   });
 });

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.ts
@@ -17,7 +17,7 @@ export class ReadingListEffects implements OnInitEffects {
           map(data =>
             ReadingListActions.loadReadingListSuccess({ list: data })
           ),
-          catchError((error) =>
+          catchError(error =>
             of(ReadingListActions.loadReadingListError({ error }))
           )
         )
@@ -55,9 +55,33 @@ export class ReadingListEffects implements OnInitEffects {
     )
   );
 
+  markBookAsFinished$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(ReadingListActions.markBookAsFinished),
+      concatMap(({ item }) =>
+        this.http
+          .put(`${API_PATH.READING_LIST}/${item.bookId}/finished`, item)
+          .pipe(
+            map(() =>
+              ReadingListActions.confirmedMarkBookAsFinished({
+                item
+              })
+            ),
+            catchError(error =>
+              of(
+                ReadingListActions.failedMarkBookAsFinished({
+                  item
+                })
+              )
+            )
+          )
+      )
+    )
+  );
+
   ngrxOnInitEffects() {
     return ReadingListActions.init();
   }
 
-  constructor(private actions$: Actions, private http: HttpClient) {}
+  constructor(private actions$: Actions, private http: HttpClient) { }
 }

--- a/libs/books/data-access/src/lib/+state/reading-list.reducer.spec.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.reducer.spec.ts
@@ -56,9 +56,7 @@ describe('Books Reducer', () => {
   describe('unknown action', () => {
     it('should return the previous state', () => {
       const action = {} as any;
-
       const result = reducer(initialState, action);
-
       expect(result).toEqual(initialState);
     });
   });

--- a/libs/books/data-access/src/lib/+state/reading-list.reducer.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.reducer.ts
@@ -18,33 +18,33 @@ export interface ReadingListPartialState {
 export const readingListAdapter: EntityAdapter<ReadingListItem> = createEntityAdapter<
   ReadingListItem
 >({
-  selectId: (item) => item.bookId,
+  selectId: item => item.bookId
 });
 
 export const initialState: State = readingListAdapter.getInitialState({
   loaded: false,
-  error: null,
+  error: null
 });
 
 const readingListReducer = createReducer(
   initialState,
-  on(ReadingListActions.init, (state) => {
+  on(ReadingListActions.init, state => {
     return {
       ...state,
       loaded: false,
-      error: null,
+      error: null
     };
   }),
   on(ReadingListActions.loadReadingListSuccess, (state, { list }) => {
     return readingListAdapter.setAll(list, {
       ...state,
-      loaded: true,
+      loaded: true
     });
   }),
   on(ReadingListActions.loadReadingListError, (state, { error }) => {
     return {
       ...state,
-      error,
+      error
     };
   }),
   on(ReadingListActions.addToReadingList, (state, { book }) =>
@@ -58,6 +58,30 @@ const readingListReducer = createReducer(
   ),
   on(ReadingListActions.failedRemoveFromReadingList, (state, { item }) =>
     readingListAdapter.addOne(item, state)
+  ),
+  on(ReadingListActions.markBookAsFinished, (state, { item }) =>
+    readingListAdapter.updateOne(
+      {
+        id: item.bookId,
+        changes: {
+          ...item,
+          finished: true
+        }
+      },
+      state
+    )
+  ),
+  on(ReadingListActions.failedMarkBookAsFinished, (state, { item }) =>
+    readingListAdapter.updateOne(
+      {
+        id: item.bookId,
+        changes: {
+          finished: false,
+          finishedDate: undefined
+        }
+      },
+      state
+    )
   )
 );
 

--- a/libs/books/data-access/src/lib/+state/reading-list.selectors.spec.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.selectors.spec.ts
@@ -1,51 +1,101 @@
-import { initialState, readingListAdapter } from './reading-list.reducer';
+import * as ReadingListActions from './reading-list.actions';
 import {
-  booksAdapter,
-  initialState as booksInitialState
-} from './books.reducer';
-import * as ToReadSelectors from './reading-list.selectors';
+  initialState,
+  readingListAdapter,
+  reducer,
+  State
+} from './reading-list.reducer';
 import { createBook, createReadingListItem } from '@tmo/shared/testing';
 
-describe('ReadingList Selectors', () => {
-  let state;
+describe('Books Reducer', () => {
+  describe('valid Books actions', () => {
+    let state: State;
 
-  beforeEach(() => {
-    state = {
-      books: booksAdapter.addMany(
-        [createBook('A'), createBook('B'), createBook('C')],
-        {
-          ...booksInitialState,
-          error: 'Unknown error',
-          loaded: true
-        }
-      ),
-      readingList: readingListAdapter.addMany(
-        [
-          createReadingListItem('A'),
-          createReadingListItem('B'),
-          createReadingListItem('C')
-        ],
-        {
-          ...initialState,
-          error: 'Unknown error',
-          loaded: true
-        }
-      )
-    };
-  });
-
-  describe('Books Selectors', () => {
-    it('getReadingList() should return the list of Books', () => {
-      const results = ToReadSelectors.getReadingList(state);
-
-      expect(results.length).toBe(3);
-      expect(results.map(x => x.bookId)).toEqual(['A', 'B', 'C']);
+    beforeEach(() => {
+      state = readingListAdapter.setAll(
+        [createReadingListItem('A'), createReadingListItem('B')],
+        initialState
+      );
     });
 
-    it("getTotalUnread() should return the current 'loaded' status", () => {
-      const result = ToReadSelectors.getTotalUnread(state);
+    it('loadBooksSuccess should load books from reading list', () => {
+      const list = [
+        createReadingListItem('A'),
+        createReadingListItem('B'),
+        createReadingListItem('C')
+      ];
+      const action = ReadingListActions.loadReadingListSuccess({ list });
 
-      expect(result).toBe(3);
+      const result: State = reducer(initialState, action);
+
+      expect(result.loaded).toBe(true);
+      expect(result.ids.length).toEqual(3);
+    });
+
+    it('failedAddToReadingList should undo book addition to the state', () => {
+      const action = ReadingListActions.failedAddToReadingList({
+        book: createBook('B')
+      });
+
+      const result: State = reducer(state, action);
+
+      expect(result.ids).toEqual(['A']);
+    });
+
+    it('failedRemoveFromReadingList should undo book removal from the state', () => {
+      const action = ReadingListActions.failedRemoveFromReadingList({
+        item: createReadingListItem('C')
+      });
+
+      const result: State = reducer(state, action);
+
+      expect(result.ids).toEqual(['A', 'B', 'C']);
+    });
+
+    it('markBookAsFinished should update finished and finishedDate fields for item in the reading list', () => {
+      const item = {
+        ...createReadingListItem('A'),
+        finished: true,
+        finishedDate: '2021-03-03T00:00:00.000Z'
+      };
+      const action = ReadingListActions.markBookAsFinished({
+        item
+      });
+
+      const result: State = reducer(state, action);
+      expect(result.entities['A']).toEqual({
+        ...item,
+        finished: true,
+        finishedDate: '2021-03-03T00:00:00.000Z'
+      });
+    });
+
+    it('failedMarkBookAsFinished should reset finished and finishedDate fields for item in the reading list', () => {
+      const item = {
+        ...createReadingListItem('A'),
+        finished: true,
+        finishedDate: '2022-02-03T00:00:00.000Z'
+      };
+      const action = ReadingListActions.failedMarkBookAsFinished({
+        item
+      });
+
+      const result: State = reducer(state, action);
+      expect(result.entities['A']).toEqual({
+        ...item,
+        finished: false,
+        finishedDate: undefined
+      });
+    });
+  });
+
+  describe('unknown action', () => {
+    it('should return the previous state', () => {
+      const action = {} as any;
+
+      const result = reducer(initialState, action);
+
+      expect(result).toEqual(initialState);
     });
   });
 });

--- a/libs/books/data-access/src/lib/+state/reading-list.selectors.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.selectors.ts
@@ -27,6 +27,7 @@ export const getReadingListEntities = createSelector(
 
 export interface ReadingListBook extends Book, Omit<ReadingListItem, 'bookId'> {
   isAdded: boolean;
+  finished: boolean
 }
 
 export const getAllBooks = createSelector<
@@ -35,7 +36,12 @@ export const getAllBooks = createSelector<
   Record<string, ReadingListItem>,
   ReadingListBook[]
 >(getBooks, getReadingListEntities, (books, entities) => {
-  return books.map(b => ({ ...b, isAdded: Boolean(entities[b.id]) }));
+  return books.map(b => ({
+    ...b,
+    isAdded: Boolean(entities[b.id]),
+    finished: Boolean(entities[b.id]?.finished),
+    finishedDate: entities[b.id]?.finishedDate
+  }));
 });
 
 export const getReadingList = createSelector(getReadingListState, selectAll);

--- a/libs/books/feature/src/lib/book-search/book-search.component.html
+++ b/libs/books/feature/src/lib/book-search/book-search.component.html
@@ -1,25 +1,16 @@
 <form [formGroup]="searchForm" (submit)="searchBooks()">
   <mat-form-field floatLabel="never">
-    <input
-      autoFocus
-      matInput
-      type="search"
-      placeholder="Search for books to add to your reading list"
-      formControlName="term"
-    />
+    <input autoFocus matInput type="search" placeholder="Search for books to add to your reading list"
+      formControlName="term" />
     <button class="search-icon" aria-label="Search" mat-icon-button matSuffix>
       <mat-icon>search</mat-icon>
     </button>
   </mat-form-field>
 </form>
 
-<ng-container *ngIf= "searchForm.value.term; else empty">
+<ng-container *ngIf="searchForm.value.term; else empty">
   <div class="book-grid">
-    <div
-      class="book"
-      data-testing="book-item"
-      *ngFor="let book of books$ | async"
-    >
+    <div class="book" data-testing="book-item" *ngFor="let book of books$ | async">
       <div class="book--title">
         {{ book.title }}
       </div>
@@ -36,14 +27,10 @@
           </div>
           <p [innerHTML]="book.description"></p>
           <div>
-            <button
-              mat-flat-button
-              color="primary"
-              (click)="addBookToReadingList(book)"
+            <button mat-flat-button data-testing="want-to-read-btn" color="primary" (click)="addBookToReadingList(book)" 
               [disabled]="book.isAdded"
-              [attr.aria-label]="'Want to read ' + book.title"
-            >
-              Want to Read
+              [attr.aria-label]="'Want to read ' + book.title">
+              {{ book.finished ? 'Finished' : 'Want to Read' }}
             </button>
           </div>
         </div>
@@ -54,11 +41,8 @@
 <ng-template #empty>
   <div class="empty">
     <p>
-      Try searching for a topic, for example "<button
-        (click)="searchExample()"
-      >
-        JavaScript</button
-      >".
+      Try searching for a topic, for example "<button (click)="searchExample()">
+        JavaScript</button>".
     </p>
   </div>
 </ng-template>

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.html
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.html
@@ -1,24 +1,34 @@
 <ng-container *ngIf="(readingList$ | async).length > 0; else empty">
-  <div class="reading-list-item" *ngFor="let book of readingList$ | async">
+  <div class="reading-list-item" data-testing="reading-list-item" *ngFor="let book of readingList$ | async">
     <div>
       <img class="reading-list-item--cover" [src]="book.coverUrl" alt="" />
     </div>
     <div class="reading-list-item--details">
       <strong class="reading-list-item--details--title">{{
         book.title
-      }}</strong>
+        }}</strong>
       <div class="reading-list-item--details--author">
-        {{ book.authors.join(',') }}
+        {{ book.authors?.join(',') }}
+      </div>
+      <div *ngIf="book.finished" class="reading-list-item--details--finished-date" data-testing="finished-date">
+        <strong><i>Finished on {{ book.finishedDate | date: 'M/d/yyyy' }}</i></strong>
       </div>
     </div>
     <div>
-      <button
-        mat-icon-button
-        color="warn"
-        [attr.aria-label]="'Remove ' + book.title + ' from reading list'"
-        (click)="removeFromReadingList(book)"
-      >
+      <button mat-icon-button 
+        data-testing="remove-btn"
+        color="warn" [attr.aria-label]="'Remove ' + book.title + ' from reading list'"
+        (click)="removeFromReadingList(book)">
         <mat-icon>remove_circle</mat-icon>
+      </button>
+    </div>
+    <div>
+      <button mat-icon-button 
+      data-testing="finished-btn"
+          [attr.aria-label]="
+          'Mark ' + book.title + ' as finished from reading list'
+        " (click)="markBookAsFinished(book)">
+        <mat-icon [ngStyle]="{ color: book.finished ? 'green' : 'red' }">done</mat-icon>
       </button>
     </div>
   </div>

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.scss
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.scss
@@ -4,6 +4,7 @@
   display: block;
   font-size: 0.75rem;
 }
+
 .reading-list {
   padding: $spacing-xxs;
 }
@@ -14,10 +15,22 @@
   margin-bottom: $spacing-xs;
   width: 100%;
 
-  > * {
+  >* {
     display: flex;
     flex-direction: column;
     justify-content: center;
+  }
+
+  .reading-list-item--buttons {
+    flex-direction: row;
+
+    .mark-finish-icon {
+      color: $gray40;
+    }
+
+    .finished-icon {
+      color: $green-dark;
+    }
   }
 }
 
@@ -34,7 +47,8 @@
 }
 
 .reading-list-item--details--title,
-.reading-list-item--details--author {
+.reading-list-item--details--author,
+.reading-list-item--details--finished-date {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.ts
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.ts
@@ -1,6 +1,11 @@
 import { Component } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { getReadingList, removeFromReadingList } from '@tmo/books/data-access';
+import {
+  getReadingList,
+  removeFromReadingList,
+  markBookAsFinished
+} from '@tmo/books/data-access';
+import { ReadingListItem } from '@tmo/shared/models';
 
 @Component({
   selector: 'tmo-reading-list',
@@ -10,9 +15,20 @@ import { getReadingList, removeFromReadingList } from '@tmo/books/data-access';
 export class ReadingListComponent {
   readingList$ = this.store.select(getReadingList);
 
-  constructor(private readonly store: Store) {}
+  constructor(private readonly store: Store) { }
 
   removeFromReadingList(item) {
     this.store.dispatch(removeFromReadingList({ item }));
+  }
+
+  markBookAsFinished(item: ReadingListItem): void {
+    this.store.dispatch(
+      markBookAsFinished({
+        item: {
+          ...item,
+          finishedDate: new Date().toISOString()
+        }
+      })
+    );
   }
 }

--- a/libs/shared/styles/src/lib/variables.scss
+++ b/libs/shared/styles/src/lib/variables.scss
@@ -11,6 +11,7 @@ $gray70: #4c4c4c;
 $gray80: #333333;
 $gray85: #262626;
 $black: #000000;
+$green-dark: #088000;
 $white: #ffffff;
 $spacing-3xs: 0.25rem;
 $spacing-xxs: 0.5rem;


### PR DESCRIPTION
As a user, I want to be able to mark a book as finished in my reading list.

Starting from the chore/code-review branch from Task 1, create a new branch feat/mark-as-read.
Update the api code to provide a new PUT /api/reading-list/:id/finished endpoint.
This endpoint should update the finished flag to true and set finishedDate as an ISO date string (e.g. 2020-01-01T00:00:00.000Z).
Update the UI to allow user to mark a book as finished from the reading list sidenav. (Bonus points for a thoughtful UI/UX design for this feature)
Indicate the book as finished in the sidenav, including the finished date.
The user can still remove the book from their reading list. Removing a book will reset the finished status (i.e. if they add the book back it will not be finished).
The Want to Read button should change to Finished.
Write a new e2e test in apps/okreads-e2e/src/specs/reading-list.spec.ts to test the new mark as finished feature.